### PR TITLE
export clamp as named export and not default

### DIFF
--- a/clamp.js
+++ b/clamp.js
@@ -13,7 +13,7 @@
     define([], factory);
   } else if (typeof exports === 'object') {
     // Node, CommonJS-like
-    module.exports = factory();
+    module.exports = {clamp: factory()};
   } else {
     // Browser globals
     root.$clamp = factory();


### PR DESCRIPTION
Currently importing this lib using es6 modules does not work. This is due to a bug in the way the lib is exported. Currently, the function "clamp" is exported using default export (module.export = clamp). This worked for the original "clamp.js". However, here the default import namespace will be "clampJsMain" and thus import default does not work.

Solution in this PR: As we still wish to keep the function name "clamp", lets move to named export and not default export. this enabled a clean "import { clamp } from "clamp-js-main" - solving this issue.

BTW tested it. it works nicely (: